### PR TITLE
Added support for 3rd Party AWS S3 based Object Storage Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ URL Format: `s3://[credential_type@]bucket[/path/to/file/or/folder][?param1=valu
 ```json
 {
     "folders": [{
-        "uri": "s3://my-bucket/?acl=public-read",
+        "uri": "s3://my-bucket/?acl=public-read&endpoint=https://aws-s3-endpoint",
         "name": "My S3 Bucket"
     }]
 }

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
         "compile": "tsc -p ./",
         "watch": "tsc -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install",
+        "pack":"vsce package",
         "test": "npm run compile && node ./node_modules/vscode/bin/test",
         "publish": "node ./publish.js"
     },

--- a/src/fs/s3.ts
+++ b/src/fs/s3.ts
@@ -271,14 +271,14 @@ export class S3FileSystem extends vscrw_fs.FileSystemBase {
             )
         );
 
-        const AS_FULL_PATH = (p: string) => {
-            p = vscode_helpers.toStringSafe(p);
-            if (!Path.isAbsolute(p)) {
-                p = Path.join(AWS_DIR, p);
-            }
+        // const AS_FULL_PATH = (p: string) => {
+        //     p = vscode_helpers.toStringSafe(p);
+        //     if (!Path.isAbsolute(p)) {
+        //         p = Path.join(AWS_DIR, p);
+        //     }
 
-            return Path.resolve( p );
-        };
+        //     return Path.resolve( p );
+        // };
 
         let credentialClass: any;
         let credentialConfig: any;
@@ -375,17 +375,24 @@ export class S3FileSystem extends vscrw_fs.FileSystemBase {
             };
         }
 
+        const s3ConnectionPayload = {
+            apiVersion: api,
+            logger: logger,
+            credentials: new credentialClass(credentialConfig),
+            endpoint: endpoint,
+            params: {
+                Bucket: this.getBucket( uri ),
+                ACL: this.getDefaultAcl(),
+            },
+        }
+
+        if(endpoint && !endpoint.includes("amazonaws.com")){
+            s3ConnectionPayload['s3ForcePathStyle'] = true;
+            s3ConnectionPayload['signatureVersion'] = "v4"
+        }
+
         const S3: S3Connection = {
-            client: new AWS.S3({
-                apiVersion: api,
-                logger: logger,
-                credentials: new credentialClass(credentialConfig),
-                endpoint: endpoint,
-                params: {
-                    Bucket: this.getBucket( uri ),
-                    ACL: this.getDefaultAcl(),
-                },
-            }),
+            client: new AWS.S3(s3ConnectionPayload),
         };
 
         return S3;


### PR DESCRIPTION
Now, we can browse non-AWS S3 Object storage providers such as but not limited to:
- Google Cloud Buckets
- Digitalocean Spaces
- Linode Object Storage
- Scaleway Object Storage
- IBM Object Storage
- OVH Cloud
- Oracle Cloud
- Cloudflare R2